### PR TITLE
export entity collisions to output

### DIFF
--- a/nsim.py
+++ b/nsim.py
@@ -642,6 +642,9 @@ class Entity:
             self.cell = cell_new
             self.sim.entity_dic[self.cell].append(self)
 
+    def log(self, state = 1):
+        self.sim.entitylog.append((self.sim.frame, self.type, self.xpos, self.ypos, state))
+
 
 class EntityGold(Entity):
     RADIUS = 6
@@ -658,7 +661,24 @@ class EntityGold(Entity):
                                     ninja.xpos, ninja.ypos, ninja.RADIUS):
             self.collected = self.sim.frame
             self.active = False
+            self.log()
 
+class EntityToggleMine(Entity):
+    RADIUS = 3.5
+
+    def __init__(self, type, sim, xcoord, ycoord):
+        super().__init__(type, sim, xcoord, ycoord)
+        self.is_logical_collidable = True
+        self.toggled = False
+
+    def logical_collision(self):
+        """If the ninja is colliding with the toggle mine, store the collection frame."""
+        ninja = self.sim.ninja
+        if overlap_circle_vs_circle(self.xpos, self.ypos, self.RADIUS,
+                                    ninja.xpos, ninja.ypos, ninja.RADIUS):
+            self.toggled = self.sim.frame
+            self.active = False
+            self.log(2)
 
 class EntityExit(Entity):
     RADIUS = 12
@@ -694,6 +714,7 @@ class EntityExitSwitch(Entity):
             self.collected = True
             self.active = False
             self.sim.entity_dic[self.parent.cell].append(self.parent) #Add door to the entity grid so the ninja can touch it
+            self.log()
 
 
 class EntityDoorBase(Entity):
@@ -783,6 +804,7 @@ class EntityDoorLocked(EntityDoorBase):
                                     ninja.xpos, ninja.ypos, ninja.RADIUS):
             self.change_state(closed = False)
             self.active = False
+            self.log()
 
 
 class EntityDoorTrap(EntityDoorBase):
@@ -799,6 +821,7 @@ class EntityDoorTrap(EntityDoorBase):
                                     ninja.xpos, ninja.ypos, ninja.RADIUS):
             self.change_state(closed = True)
             self.active = False
+            self.log()
 
 
 class EntityLaunchPad(Entity):
@@ -1204,6 +1227,7 @@ class Simulator:
 
     def __init__(self):
         self.frame = 1
+        self.entitylog = []
 
         #initiate a dictionary mapping each tile id to its cell. Start by filling it with full tiles (id of 1).
         self.tile_dic = {}
@@ -1354,6 +1378,8 @@ class Simulator:
                 entity = EntityBounceBlock(type, self, xcoord, ycoord)
             elif type == 20:
                 entity = EntityThwump(type, self, xcoord, ycoord, orientation)
+            elif type == 21:
+                entity = EntityToggleMine(type, self, xcoord, ycoord)
             elif type == 24:
                 entity = EntityBoostPad(type, self, xcoord, ycoord)
             elif type == 28:

--- a/ntrace.py
+++ b/ntrace.py
@@ -83,6 +83,7 @@ yposlog = []
 goldlog = []
 frameslog = []
 validlog = []
+entitylog = []
 
 #This dictionary converts raw input data into the horizontal and jump components.
 HOR_INPUTS_DIC = {0:0, 1:0, 2:1, 3:1, 4:-1, 5:-1, 6:-1, 7:-1}
@@ -112,6 +113,7 @@ for i in range(len(inputs_list)):
     #Append the positions log of each replay
     xposlog.append(sim.ninja.xposlog)
     yposlog.append(sim.ninja.yposlog)
+    entitylog.append(sim.entitylog)
 
     #Calculate the amount of gold collected for each replay.
     gold_amount = mdata[1154]
@@ -187,10 +189,17 @@ if tool_mode == "trace" and OUTTE_MODE == False:
 #of coordinates for each frame. Only ran in outte mode and in trace mode.
 if tool_mode == "trace" and OUTTE_MODE == True:
     with open("output.bin", "wb") as f:
+        # Write run count, and then valid log (1 byte per run)
         n = len(inputs_list)
         f.write(struct.pack('B', n))
         f.write(struct.pack(f'{n}B', *validlog))
         for i in range(n):
+            # Entity log: Write collided entities count and then dump log
+            objs = len(entitylog[i])
+            f.write(struct.pack('<H', objs))
+            for obj in range(objs):
+                f.write(struct.pack('<HBddB', *entitylog[i][obj]))
+            # Position log: Write frame count and then dump log
             frames = len(xposlog[i])
             f.write(struct.pack('<H', frames))
             for frame in range(frames):


### PR DESCRIPTION
Also include relevant entity collisions in ntrace's binary output file, so that outte can read that directly instead of recalculating them and risking imprecisions.

I added the EntityToggleMine class so that those are supported too, although I'm not tracking the intermediate "toggling" state.

Only collisions with gold, toggles and switches (locked / trap / exit) are logged. For each collision we export this info:
`(frame, ID, X, Y, state)`
Which is enough for outte to find the relevant object and change it accordingly.